### PR TITLE
compatibility with trinkets and higher soaring winds levels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,14 @@ repositories {
 			includeGroup "maven.modrinth"
 		}
 	}
+	maven {
+		name = "TerraformersMC"
+		url = "https://maven.terraformersmc.com/"
+	}
+	maven {
+		name = "Ladysnake Libs"
+		url = 'https://maven.ladysnake.org/releases'
+	}
 }
 
 dependencies {
@@ -38,6 +46,7 @@ dependencies {
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
 	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+	modCompileOnly("dev.emi:trinkets:${trinkets_version}")
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 
 # Dependencies
 	fabric_version=0.83.0+1.20.1
+	trinkets_version=3.7.1

--- a/src/main/java/net/Pandarix/betterarcheology/enchantment/SoaringWindsEnchantment.java
+++ b/src/main/java/net/Pandarix/betterarcheology/enchantment/SoaringWindsEnchantment.java
@@ -1,5 +1,6 @@
 package net.Pandarix.betterarcheology.enchantment;
 
+import net.Pandarix.betterarcheology.util.ModConfigs;
 import net.minecraft.enchantment.EnchantmentTarget;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.item.ElytraItem;
@@ -12,7 +13,7 @@ public class SoaringWindsEnchantment extends ArtifactEnchantment {
 
     @Override
     public int getMaxLevel() {
-        return 1;
+        return ModConfigs.SOARING_WINDS_MAXLEVEL;
     }
 
     @Override

--- a/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
+++ b/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
@@ -7,6 +7,8 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.predicate.NbtPredicate;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -14,28 +16,90 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.ArrayList;
+
 @Mixin(PlayerEntity.class)
 public abstract class ElytraStartupMixin {
     @Shadow public abstract ItemStack getEquippedStack(EquipmentSlot slot);
 
+    @Shadow public abstract void readCustomDataFromNbt(NbtCompound nbt);
+
+    @Shadow public abstract void writeCustomDataToNbt(NbtCompound nbt);
+
     @Inject(method = "startFallFlying", at = @At(value = "TAIL"))
     private void injectMethod(CallbackInfo ci){
-        //if it is enabled in the config and the chestslot is enchanted
-        if(ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED && this.getEquippedStack(EquipmentSlot.CHEST).hasEnchantments()){
-            //if the enchantment in the chestslot is soaring winds
-            if(EnchantmentHelper.getLevel(ModEnchantments.SOARING_WINDS, this.getEquippedStack(EquipmentSlot.CHEST)) == 1){
+        //add a bool to specify if soaring winds should trigger
+        boolean launchWithSoaringWinds = false;
+        int enchantmentLevel = 0;
 
-                PlayerEntity betterarcheology$player = (PlayerEntity) (Object) this;
-                float betterarcheology$boost = ModConfigs.SOARING_WINDS_BOOST * 0.5f;
-                Vec3d betterarcheology$vec3d = betterarcheology$player.getRotationVector();
-                Vec3d betterarcheology$vec3d2 = betterarcheology$player.getVelocity();
+        if(ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED){
+            //create an arraylist of all items that are checked for the enchantment
+            ArrayList<ItemStack> itemsToCheck = new ArrayList<ItemStack>();
+            itemsToCheck.add(this.getEquippedStack(EquipmentSlot.CHEST));
 
-                //add player velocity when starting to fall-fly
-                betterarcheology$player.setVelocity(betterarcheology$vec3d2.add(
-                        betterarcheology$vec3d.x * 0.1 + (betterarcheology$vec3d.x * 1.5 - betterarcheology$vec3d2.x) * betterarcheology$boost,
-                        betterarcheology$vec3d.y * 0.1 + (betterarcheology$vec3d.y * 1.5 - betterarcheology$vec3d2.y) * betterarcheology$boost/2,
-                        betterarcheology$vec3d.z * 0.1 + (betterarcheology$vec3d.z * 1.5 - betterarcheology$vec3d2.z) * betterarcheology$boost));
+            if (ModConfigs.ELYTRA_TRINKETS_COMPATIBILITY) {
+                //check if the trinktes mod is installed and there is nbt data for it on the player
+                NbtCompound nbtData = NbtPredicate.entityToNbt((PlayerEntity) (Object) this);
+                NbtCompound trinketsData = null;
+                try{
+                    trinketsData= nbtData.getCompound("cardinal_components").getCompound("trinkets:trinkets");
+                }catch(Exception e){
+                    BetterArcheology.LOGGER.info("No trinkets data found");
+                }
+
+                //if there is trinkets data, check chest/* slot for an elytra with soaring winds
+                ArrayList<String> chestSlots = new ArrayList<String>();
+                chestSlots.add("back");
+                chestSlots.add("cape");
+
+                if(trinketsData != null){
+                    var chestData = trinketsData.getCompound("chest");
+                    if(chestData != null){
+                        for(int slotIndex = 0; slotIndex < chestSlots.size(); slotIndex++){
+                            try {
+                                var slotData = chestData.getCompound(chestSlots.get(slotIndex));
+                                if (slotData != null) {
+                                    var slotItems = slotData.getList("Items", 10);
+
+                                    for (int itemIndex = 0; itemIndex < slotItems.size(); itemIndex++) {
+                                        itemsToCheck.add(ItemStack.fromNbt(slotItems.getCompound(itemIndex)));
+                                    }
+                                }
+                            }catch(Exception e){}
+                        }
+                    }
+                }
             }
+
+            //check all slots for an elytra with the soaring winds enchantment
+            for(ItemStack item : itemsToCheck){
+                if(!item.hasEnchantments()) {
+                    continue;
+                }
+
+                //get the enchantment level of soaring winds and enable the launch if its greater than 0
+                enchantmentLevel = EnchantmentHelper.getLevel(ModEnchantments.SOARING_WINDS, item);
+                if(enchantmentLevel > 0){
+                    launchWithSoaringWinds = true;
+                    break;
+                }
+
+            }
+        }
+
+        //actually launch with soaring winds
+        if(launchWithSoaringWinds){
+            PlayerEntity betterarcheology$player = (PlayerEntity) (Object) this;
+            float betterarcheology$boost = enchantmentLevel * ModConfigs.SOARING_WINDS_BOOST * 0.5f;
+            Vec3d betterarcheology$vec3d = betterarcheology$player.getRotationVector();
+            Vec3d betterarcheology$vec3d2 = betterarcheology$player.getVelocity();
+
+            //add player velocity when starting to fall-fly
+            betterarcheology$player.setVelocity(betterarcheology$vec3d2.add(
+                    betterarcheology$vec3d.x * 0.1 + (betterarcheology$vec3d.x * 1.5 - betterarcheology$vec3d2.x) * betterarcheology$boost,
+                    betterarcheology$vec3d.y * 0.1 + (betterarcheology$vec3d.y * 1.5 - betterarcheology$vec3d2.y) * betterarcheology$boost/2,
+                    betterarcheology$vec3d.z * 0.1 + (betterarcheology$vec3d.z * 1.5 - betterarcheology$vec3d2.z) * betterarcheology$boost));
+
         }
     }
 }

--- a/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
+++ b/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
@@ -2,41 +2,27 @@ package net.Pandarix.betterarcheology.mixin;
 
 import net.Pandarix.betterarcheology.util.ModConfigs;
 import net.Pandarix.betterarcheology.util.ElytraHelper;
-import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PlayerEntity.class)
 public abstract class ElytraStartupMixin {
-    @Shadow public abstract ItemStack getEquippedStack(EquipmentSlot slot);
-
     @Inject(method = "startFallFlying", at = @At(value = "TAIL"))
     private void injectMethod(CallbackInfo ci){
-        if(!ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED){
-            return;
-        }
-
-        int enchantmentLevel = ElytraHelper.getSoaringWindsLevel((PlayerEntity) (Object) this);
-
-        //actually launch with soaring winds
-        if(enchantmentLevel > 0){
+        if(ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED) {
             PlayerEntity betterarcheology$player = (PlayerEntity) (Object) this;
-            float betterarcheology$boost = enchantmentLevel * ModConfigs.SOARING_WINDS_BOOST * 0.5f;
-            Vec3d betterarcheology$vec3d = betterarcheology$player.getRotationVector();
-            Vec3d betterarcheology$vec3d2 = betterarcheology$player.getVelocity();
+            int betterarcheology$enchantmentLevel = ElytraHelper.getSoaringWindsLevel(betterarcheology$player);
 
-            //add player velocity when starting to fall-fly
-            betterarcheology$player.setVelocity(betterarcheology$vec3d2.add(
-                    betterarcheology$vec3d.x * 0.1 + (betterarcheology$vec3d.x * 1.5 - betterarcheology$vec3d2.x) * betterarcheology$boost,
-                    betterarcheology$vec3d.y * 0.1 + (betterarcheology$vec3d.y * 1.5 - betterarcheology$vec3d2.y) * betterarcheology$boost/2,
-                    betterarcheology$vec3d.z * 0.1 + (betterarcheology$vec3d.z * 1.5 - betterarcheology$vec3d2.z) * betterarcheology$boost));
+            //actually launch with soaring winds
+            if (betterarcheology$enchantmentLevel > 0) {
+                float betterarcheology$boost = betterarcheology$enchantmentLevel * ModConfigs.SOARING_WINDS_BOOST * 0.5f;
 
+                ElytraHelper.applyElytraBoost(betterarcheology$player, new Vec3d(betterarcheology$boost, betterarcheology$boost/2, betterarcheology$boost));
+            }
         }
     }
 }

--- a/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
+++ b/src/main/java/net/Pandarix/betterarcheology/mixin/ElytraStartupMixin.java
@@ -1,14 +1,10 @@
 package net.Pandarix.betterarcheology.mixin;
 
-import net.Pandarix.betterarcheology.BetterArcheology;
-import net.Pandarix.betterarcheology.enchantment.ModEnchantments;
 import net.Pandarix.betterarcheology.util.ModConfigs;
-import net.minecraft.enchantment.EnchantmentHelper;
+import net.Pandarix.betterarcheology.util.ElytraHelper;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NbtCompound;
-import net.minecraft.predicate.NbtPredicate;
 import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -16,79 +12,20 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.ArrayList;
-
 @Mixin(PlayerEntity.class)
 public abstract class ElytraStartupMixin {
     @Shadow public abstract ItemStack getEquippedStack(EquipmentSlot slot);
 
-    @Shadow public abstract void readCustomDataFromNbt(NbtCompound nbt);
-
-    @Shadow public abstract void writeCustomDataToNbt(NbtCompound nbt);
-
     @Inject(method = "startFallFlying", at = @At(value = "TAIL"))
     private void injectMethod(CallbackInfo ci){
-        //add a bool to specify if soaring winds should trigger
-        boolean launchWithSoaringWinds = false;
-        int enchantmentLevel = 0;
-
-        if(ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED){
-            //create an arraylist of all items that are checked for the enchantment
-            ArrayList<ItemStack> itemsToCheck = new ArrayList<ItemStack>();
-            itemsToCheck.add(this.getEquippedStack(EquipmentSlot.CHEST));
-
-            if (ModConfigs.ELYTRA_TRINKETS_COMPATIBILITY) {
-                //check if the trinktes mod is installed and there is nbt data for it on the player
-                NbtCompound nbtData = NbtPredicate.entityToNbt((PlayerEntity) (Object) this);
-                NbtCompound trinketsData = null;
-                try{
-                    trinketsData= nbtData.getCompound("cardinal_components").getCompound("trinkets:trinkets");
-                }catch(Exception e){
-                    BetterArcheology.LOGGER.info("No trinkets data found");
-                }
-
-                //if there is trinkets data, check chest/* slot for an elytra with soaring winds
-                ArrayList<String> chestSlots = new ArrayList<String>();
-                chestSlots.add("back");
-                chestSlots.add("cape");
-
-                if(trinketsData != null){
-                    var chestData = trinketsData.getCompound("chest");
-                    if(chestData != null){
-                        for(int slotIndex = 0; slotIndex < chestSlots.size(); slotIndex++){
-                            try {
-                                var slotData = chestData.getCompound(chestSlots.get(slotIndex));
-                                if (slotData != null) {
-                                    var slotItems = slotData.getList("Items", 10);
-
-                                    for (int itemIndex = 0; itemIndex < slotItems.size(); itemIndex++) {
-                                        itemsToCheck.add(ItemStack.fromNbt(slotItems.getCompound(itemIndex)));
-                                    }
-                                }
-                            }catch(Exception e){}
-                        }
-                    }
-                }
-            }
-
-            //check all slots for an elytra with the soaring winds enchantment
-            for(ItemStack item : itemsToCheck){
-                if(!item.hasEnchantments()) {
-                    continue;
-                }
-
-                //get the enchantment level of soaring winds and enable the launch if its greater than 0
-                enchantmentLevel = EnchantmentHelper.getLevel(ModEnchantments.SOARING_WINDS, item);
-                if(enchantmentLevel > 0){
-                    launchWithSoaringWinds = true;
-                    break;
-                }
-
-            }
+        if(!ModConfigs.ARTIFACT_ENCHANTMENTS_ENABLED){
+            return;
         }
 
+        int enchantmentLevel = ElytraHelper.getSoaringWindsLevel((PlayerEntity) (Object) this);
+
         //actually launch with soaring winds
-        if(launchWithSoaringWinds){
+        if(enchantmentLevel > 0){
             PlayerEntity betterarcheology$player = (PlayerEntity) (Object) this;
             float betterarcheology$boost = enchantmentLevel * ModConfigs.SOARING_WINDS_BOOST * 0.5f;
             Vec3d betterarcheology$vec3d = betterarcheology$player.getRotationVector();

--- a/src/main/java/net/Pandarix/betterarcheology/util/ElytraHelper.java
+++ b/src/main/java/net/Pandarix/betterarcheology/util/ElytraHelper.java
@@ -8,6 +8,7 @@ import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.Vec3d;
 
 public class ElytraHelper {
     /**
@@ -51,5 +52,30 @@ public class ElytraHelper {
             return 0;
         }
         return EnchantmentHelper.getLevel(enchantment, item);
+    }
+
+    /**
+     * Applies a boost to a given flying player.
+     * The boost vector is first multiplied with the rotation vector component wise
+     * and then added to the velocity vector. This boosts the current velocity
+     * in the direction of the boost vector.
+     *
+     * @param player the player to boost
+     * @param vec_boost the boost vector
+     */
+    public static void applyElytraBoost(PlayerEntity player, Vec3d vec_boost){
+        if (!player.isFallFlying()){
+            return;
+        }
+
+        Vec3d vec_rot = player.getRotationVector();
+        Vec3d vec_vel = player.getVelocity();
+
+        //first multiply the boost vector with the rotation vector component wise
+        //then add the result to the velocity vector to boost the current velocity by the boost vector
+        Vec3d vec_res = vec_vel.add(vec_rot.multiply(vec_boost));
+
+        //set the new velocity
+        player.setVelocity(vec_res);
     }
 }

--- a/src/main/java/net/Pandarix/betterarcheology/util/ElytraHelper.java
+++ b/src/main/java/net/Pandarix/betterarcheology/util/ElytraHelper.java
@@ -1,0 +1,55 @@
+package net.Pandarix.betterarcheology.util;
+
+import dev.emi.trinkets.api.TrinketsApi;
+import net.Pandarix.betterarcheology.enchantment.ModEnchantments;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+
+public class ElytraHelper {
+    /**
+     * Checks if the given player has an Item with soaring winds equipped and returns the enchantment level
+     * @param player the player to check
+     * @return int the enchantment level of the item
+     */
+    public static int getSoaringWindsLevel(PlayerEntity player){
+        //check the enchantment level of the chestplate
+        int enchantmentLevel = getSafeEnchantLevel(ModEnchantments.SOARING_WINDS, player.getEquippedStack(EquipmentSlot.CHEST));
+        if(enchantmentLevel > 0){
+            return enchantmentLevel;
+        }
+
+        //if trinkets is not loaded skip it
+        if (FabricLoader.getInstance().isModLoaded("trinkets")){
+            var Trinkets = TrinketsApi.getTrinketComponent(player);
+            if (Trinkets.isPresent()) {
+                //check if the player has a trinket equipped with soaring winds and return the level
+                var trinkets = Trinkets.get().getAllEquipped();
+                for (var slot : trinkets) {
+                    enchantmentLevel = getSafeEnchantLevel(ModEnchantments.SOARING_WINDS, slot.getRight());
+                    if(enchantmentLevel > 0){
+                        return enchantmentLevel;
+                    }
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Returns the enchantment level of an item, or 0 if the item has no enchantments
+     * @param enchantment the enchantment to check
+     * @param item the item to check
+     * @return int the enchantment level of the item
+     */
+    public static int getSafeEnchantLevel(Enchantment enchantment, ItemStack item){
+        if (!item.hasEnchantments()) {
+            return 0;
+        }
+        return EnchantmentHelper.getLevel(enchantment, item);
+    }
+}

--- a/src/main/java/net/Pandarix/betterarcheology/util/ModConfigs.java
+++ b/src/main/java/net/Pandarix/betterarcheology/util/ModConfigs.java
@@ -9,6 +9,7 @@ public class ModConfigs {
     public static boolean ARTIFACT_ENCHANTMENTS_ENABLED;
     public static float PENETRATING_STRIKE_PROTECTION_IGNORANCE;
     public static float SOARING_WINDS_BOOST;
+    public static boolean ELYTRA_TRINKETS_COMPATIBILITY;
     public static int OCELOT_FOSSIL_FLEE_RANGE;
 
     public static void registerConfigs() {
@@ -24,6 +25,7 @@ public class ModConfigs {
         configs.addKeyValuePair(new Pair<>("artifact.enchantments.enabled", true), "Set to true or false to enable or disable effects");
         configs.addKeyValuePair(new Pair<>("penetrating.strike.protection.ignorance", 0.33f), "Set to % of damage-reduction from Protection Enchantments that should be ignored, keep in range of 0-1.00");
         configs.addKeyValuePair(new Pair<>("soaring.winds.boost", 0.5f), "Set to movement speed multiplier, that should be applied when starting to fly");
+        configs.addKeyValuePair(new Pair<>("elytra.trinkets.compatibility", true), "Set to true or false to enable or disable compatibility with Trinkets Mod");
         configs.addKeyValuePair(new Pair<>("ocelot.fossil.flee.range", 20), "Range in Block that the Fossil scares Creepers away");
     }
 
@@ -31,6 +33,7 @@ public class ModConfigs {
         ARTIFACT_ENCHANTMENTS_ENABLED = CONFIG.getOrDefault("artifact.enchantments.enabled", true);
         PENETRATING_STRIKE_PROTECTION_IGNORANCE = (float) CONFIG.getOrDefault("penetrating.strike.protection.ignorance", 0.33f);
         SOARING_WINDS_BOOST = (float) CONFIG.getOrDefault("soaring.winds.boost", 0.3f);
+        ELYTRA_TRINKETS_COMPATIBILITY = CONFIG.getOrDefault("elytra.trinkets.compatibility", true);
         OCELOT_FOSSIL_FLEE_RANGE = CONFIG.getOrDefault("ocelot.fossil.flee.range", 20);
 
         System.out.println("All " + configs.getConfigsList().size() + " have been set properly");

--- a/src/main/java/net/Pandarix/betterarcheology/util/ModConfigs.java
+++ b/src/main/java/net/Pandarix/betterarcheology/util/ModConfigs.java
@@ -9,7 +9,7 @@ public class ModConfigs {
     public static boolean ARTIFACT_ENCHANTMENTS_ENABLED;
     public static float PENETRATING_STRIKE_PROTECTION_IGNORANCE;
     public static float SOARING_WINDS_BOOST;
-    public static boolean ELYTRA_TRINKETS_COMPATIBILITY;
+    public static int SOARING_WINDS_MAXLEVEL;
     public static int OCELOT_FOSSIL_FLEE_RANGE;
 
     public static void registerConfigs() {
@@ -25,7 +25,7 @@ public class ModConfigs {
         configs.addKeyValuePair(new Pair<>("artifact.enchantments.enabled", true), "Set to true or false to enable or disable effects");
         configs.addKeyValuePair(new Pair<>("penetrating.strike.protection.ignorance", 0.33f), "Set to % of damage-reduction from Protection Enchantments that should be ignored, keep in range of 0-1.00");
         configs.addKeyValuePair(new Pair<>("soaring.winds.boost", 0.5f), "Set to movement speed multiplier, that should be applied when starting to fly");
-        configs.addKeyValuePair(new Pair<>("elytra.trinkets.compatibility", true), "Set to true or false to enable or disable compatibility with Trinkets Mod");
+        configs.addKeyValuePair(new Pair<>("soaring.winds.maxlevel", 1), "Set the maximum level for soaring winds");
         configs.addKeyValuePair(new Pair<>("ocelot.fossil.flee.range", 20), "Range in Block that the Fossil scares Creepers away");
     }
 
@@ -33,7 +33,7 @@ public class ModConfigs {
         ARTIFACT_ENCHANTMENTS_ENABLED = CONFIG.getOrDefault("artifact.enchantments.enabled", true);
         PENETRATING_STRIKE_PROTECTION_IGNORANCE = (float) CONFIG.getOrDefault("penetrating.strike.protection.ignorance", 0.33f);
         SOARING_WINDS_BOOST = (float) CONFIG.getOrDefault("soaring.winds.boost", 0.3f);
-        ELYTRA_TRINKETS_COMPATIBILITY = CONFIG.getOrDefault("elytra.trinkets.compatibility", true);
+        SOARING_WINDS_MAXLEVEL = CONFIG.getOrDefault("soaring.winds.maxlevel", 1);
         OCELOT_FOSSIL_FLEE_RANGE = CONFIG.getOrDefault("ocelot.fossil.flee.range", 20);
 
         System.out.println("All " + configs.getConfigsList().size() + " have been set properly");


### PR DESCRIPTION
This pr fixes #22 and adds a config flag for higher levels of soaring winds.

The latest version of the code uses trinkets as a compile only dependency to simplify the trinkets check.